### PR TITLE
fix: updated incorrect GitHub source code link

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -432,7 +432,7 @@ function Footer() {
 
       <a
         target="_blank"
-        href="https://github.com/vercel-labs/react-on-the-edge"
+        href="https://github.com/vercel/react-on-the-edge"
         class="source"
       >
         <svg


### PR DESCRIPTION
### Summary

This PR changes the link in the bottom right to the correct repository, even if it is still private at the moment.